### PR TITLE
Fixed Minor Typographical Errors

### DIFF
--- a/pages/docs/other/parser.md
+++ b/pages/docs/other/parser.md
@@ -169,10 +169,10 @@ Below are simple examples of each parser and how to use them.
 {actionRow:{selectMenu:customID:Placeholder:1:1:false:{stringInput:Option1:1:OptionDescription1:false:👋}{stringInput:Option2:2:OptionDescription2:false}}}
 ```
 
-**Multi-Select Menu with three options and and a maximum of 2 selectable options**
+**Multi-Select Menu with three options and a maximum of 2 selectable options**
 
 ```bash
-{actionRow:{selectMenu:customID:Placeholder:1:2:false:{stringInput:Option1:1:OptionDescription1:false:👋}{stringInput:Option2:2:OptionDescription2:false}{selectMenuOptions:Option3:3:OptionDescription3:false}}}
+{actionRow:{selectMenu:customID:Placeholder:1:2:false:{stringInput:Option1:1:OptionDescription1:false:👋}{stringInput:Option2:2:OptionDescription2:false}{stringInput:Option3:3:OptionDescription3:false}}}
 ```
 
 **User-Select Menu**

--- a/pages/extensions/music/index.mdx
+++ b/pages/extensions/music/index.mdx
@@ -37,7 +37,7 @@ const client = new AoiClient({
   },
 });
 
-const voice = new AoiVoice(bot, {
+const voice = new AoiVoice(client, {
   searchOptions: {
     soundcloudClientId: "Soundcloud ID", // optional
     youtubegl: "US",


### PR DESCRIPTION
Fixed minor typographical errors found at parsers guide and aoi.music extension setup.

### Changes
https://github.com/aoijs/website/commit/865374633ab7fadfa845f82981864d22b186e11a - Fixed doubled "and" word and replaced outlooked `selectMenuOptions` with `stringInput`
https://github.com/aoijs/website/commit/7ebe5cc430fcdfdf31c8026687d1193ea751b7d6 - Fixed incorrect reference to client inside `AoiVoice()`

### Files Changed
1. pages/docs/other/parser.md - https://github.com/aoijs/website/commit/865374633ab7fadfa845f82981864d22b186e11a
2. pages/extensions/music/index.mdx - https://github.com/aoijs/website/commit/7ebe5cc430fcdfdf31c8026687d1193ea751b7d6